### PR TITLE
Add babel-transform-object-rest-spread to fix JS compatibility error

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -5,6 +5,7 @@
   "plugins": [
     "preval",
     "transform-decorators-legacy",
+    "transform-object-rest-spread",
     "inline-react-svg"
   ]
 }

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "babel-plugin-module-resolver": "^3.0.0",
     "babel-plugin-preval": "^1.6.2",
     "babel-plugin-transform-decorators-legacy": "^1.3.4",
+    "babel-plugin-transform-object-rest-spread": "^6.26.0",
     "babel-plugin-wrap-in-js": "^1.1.1",
     "babel-runtime": "^6.26.0",
     "cookies-js": "^1.2.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -801,7 +801,7 @@ babel-plugin-transform-flow-strip-types@^6.22.0:
     babel-plugin-syntax-flow "^6.18.0"
     babel-runtime "^6.22.0"
 
-babel-plugin-transform-object-rest-spread@6.26.0:
+babel-plugin-transform-object-rest-spread@6.26.0, babel-plugin-transform-object-rest-spread@^6.26.0:
   version "6.26.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-transform-object-rest-spread/-/babel-plugin-transform-object-rest-spread-6.26.0.tgz#0f36692d50fef6b7e2d4b3ac1478137a963b7b06"
   dependencies:


### PR DESCRIPTION
The previous paperwork fix PRs introduced an experimental feature of Javascript that is currently [a stage 3 proposal](https://github.com/tc39/proposal-object-rest-spread). This PR adds a babel transform plugin to fix compatibility errors that have resulted from this change (see [FRH-359]( https://jira.fuelrats.com/browse/FRH-359)). According to [kangax](http://kangax.github.io/compat-table/esnext/#test-object_rest/spread_properties), official support for this feature is only in latest versions of Firefox and Chrome.