### PR TITLE
Fix 404 Return error.

### DIFF
--- a/components/Head.js
+++ b/components/Head.js
@@ -85,15 +85,12 @@ export default class extends React.Component {
         <meta name="msapplication-wide310x150logo" content="/static/favicon/mstile-310x150.png" />
         <meta name="msapplication-square310x310logo" content="/static/favicon/mstile-310x310.png" />
 
-        <meta name="viewport" content="initial-scale=1.0, width=device-width" />
-
-        <link href="//cdnjs.cloudflare.com/ajax/libs/dialog-polyfill/0.4.8/dialog-polyfill.min.css" rel="stylesheet" />
         <link href="//cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css" rel="stylesheet" />
+        
+        <meta name="viewport" content="initial-scale=1.0, width=device-width" />
 
         <style dangerouslySetInnerHTML={{ __html: libStylesheet }} />
         <style dangerouslySetInnerHTML={{ __html: appStylesheet }} />
-
-        <script src="//cdnjs.cloudflare.com/ajax/libs/dialog-polyfill/0.4.8/dialog-polyfill.min.js"></script>
         <script async defer src="//www.google.com/recaptcha/api.js?render=explicit"/>
         <script async src={`https://www.googletagmanager.com/gtag/js?id=${gaTrackingId}`} />
         <script dangerouslySetInnerHTML={{ __html: `

--- a/components/PortalDialog.js
+++ b/components/PortalDialog.js
@@ -52,7 +52,7 @@ export default class extends Component {
   }
 
   componentDidMount () {
-    if (this._el) {
+    if (this._el && dialogPolyfill) {
       dialogPolyfill.registerDialog(this._el)
 
       if (this.props.open) {

--- a/components/PortalDialog.js
+++ b/components/PortalDialog.js
@@ -52,7 +52,7 @@ export default class extends Component {
   }
 
   componentDidMount () {
-    if (this._el && dialogPolyfill) {
+    if (this._el) {
       dialogPolyfill.registerDialog(this._el)
 
       if (this.props.open) {

--- a/pages/_document.js
+++ b/pages/_document.js
@@ -4,7 +4,10 @@ export default class extends Document {
   render() {
     return (
       <html>
-        <Head />
+        <Head>
+          <link href="//cdnjs.cloudflare.com/ajax/libs/dialog-polyfill/0.4.8/dialog-polyfill.min.css" rel="stylesheet" />
+          <script src="//cdnjs.cloudflare.com/ajax/libs/dialog-polyfill/0.4.8/dialog-polyfill.min.js"></script>
+        </Head>
 
         <body>
           <div id="alert-container" />


### PR DESCRIPTION
When attempting to return from a link that leads to a 404 (pressing back), the document is loaded back into the DOM on the same tick as the page itself is. Because the 404 page lacks the head tags defined in the document, the dialogPolyfill isn't defined until after the update tick that calls this componentDidMount function completes. 

... which obviously breaks shit