### PR TITLE
i-need-fuel page 2.0

### DIFF
--- a/pages/i-need-fuel.js
+++ b/pages/i-need-fuel.js
@@ -1,3 +1,10 @@
+// Module imports
+import Link from 'next/link'
+
+
+
+
+
 // Component imports
 import Page from '../components/Page'
 
@@ -5,7 +12,7 @@ import Page from '../components/Page'
 
 
 
-// Component imports
+// Component constants
 const title = 'I Need Fuel'
 
 
@@ -25,41 +32,41 @@ const INeedFuel = () => (
           className="pull-right"
           src="https://i1.wp.com/www.fuelrats.com/wp-content/uploads/2016/07/vig_rescue_250-200x126.jpg?resize=200%2C126&ssl=1" />
 
-        <p>Click on the left button to activate a chat session. Put your CMDR name (or GamerTag if you play on XBox or PS4), current system and whether you’re on emergency o2 (Blue timer in the top right of your screen) and hit "Start". You’ll be able to see which Fuel Rats are logged in and instantly talk with everyone. If there is a "Dispatch" he/she’ll be the one assigning people to help you.</p>
+        <h5>
+          DO YOU SEE A BLUE COUNTDOWN TIMER?
+          <br />
+          If so, quit to the main menu of the game immediately!
+        </h5>
 
-        <p>If you find yourself stranded, log out to main menu and await further instructions.</p>
+        <br />
 
-        <p>If you’re just checking out the service to say "hello" that’s fine, you can press the green button to open the chat room.</p>
-
-        <p><strong>For a visual reference of these steps along with default controls, refer to these <a href="https://imgur.com/gallery/YuWa6">Emergency Fuel Procedures</a>.</strong></p>
-
-        <p>If you encounter difficulties logging into our IRC chat and need fuel, please make a post on <a href="https://www.reddit.com/r/FuelRats/">the subreddit</a> with the above mentioned information for us to assist you!</p>
-
-        <p>When you join the chat, do not send or accept friend requests in-game until instructed to do so by the dispatcher.</p>
-
-        <p>There are griefers/miscreants that occasionally try to learn the location of stranded clients. We will rescue you, but you need to protect yourself. Please note that everyone using our IRC servers are subject to the Fuel Rats’ <a href="http://t.fuelr.at/tos">Terms of Service</a> and <a href="http://t.fuelr.at/coc">Code of Conduct</a>.</p>
+        <p>Have you found yourself low on fuel and unable to make it to your nearest refuel point? Never fear! The Fuel Rats are here to help! </p>
 
         <div className="buttons">
           <a
-            className="button call-to-action"
+            className="button call-to-action green"
             href="https://clients.fuelrats.com:7778/"
             rel="noopener noreferrer"
             target="_blank">
-            Get Rescued
+            Click here to get refueled!
           </a>
 
-          <div>
-            <small>Don't need a rescue?</small>
+          <br />
 
-            <a
-              className="button green"
-              href="https://kiwi.fuelrats.com:7778/"
-              rel="noopener noreferrer"
-              target="_blank">
-              Chat with the Fuel Rats
-            </a>
-          </div>
+          <p>Don't need a fill up? Just looking to chat, or perhaps even help the cause?</p>
+
+          <a
+            className="button secondary"
+            href="https://kiwi.fuelrats.com:7778/"
+            rel="noopener noreferrer"
+            target="_blank">
+            Click here to chat with the rats!
+          </a>
         </div>
+
+        <br />
+
+        <small>By connecting to our IRC and using our services, you agree to our <Link href="/terms-of-service"><a>Terms of Service</a></Link> and <Link href="/privacy-policy"><a>Privacy Policy</a></Link>.</small>
       </div>
     </div>
   </div>

--- a/scss/pages/_i-need-fuel.scss
+++ b/scss/pages/_i-need-fuel.scss
@@ -1,6 +1,7 @@
 .page.i-need-fuel {
   .buttons {
-    align-items: flex-end;
+    align-items: flex-start;
+    flex-direction: column;
     display: flex;
     justify-content: space-between;
 


### PR DESCRIPTION
This is a redo of the i-need-fuel page. The aim is to improve usability and reduce user confusion.

A very common problem with the current page is that the user's eye is drawn towards the green "Chat with the Fuel Rats" button, and clients click that instead of the "get rescued" button. This misdirect is causing clients to land in the casual chatting channel, which is not where client rescues should be held. This issue has been addressed by increasing visibility of the correct button, and pushing the alternate chat button into the background; Away from what the client should be reading.

This new layout also aims to direct non-native English, or non-English, squeakers better. The only element that draws immediate attention from the eye is the large green button in the center of the page. This helps make it clear what button should be pressed to get rescued. Even if the client does not squeak in Modern Galactic English, a large green button is universally known as the "go" button, and should not be mistaken for anything else.

Another issue with the current page is it's large amount of confusing text. Our clients are potentially on emergency oxygen and losing time. Most are inexperienced and panicked about their current situation. Confronting them with a wall of text can not only be confusing, it could mean loss of precious time, or worse, death. Replacing this with some friendly and inviting language, and a notice for CR clients, can help lower overall confusion in what steps to take, as well as reassure the player they are putting their rebuy money in good hands.

In the past, we have had issues with a few clients who have tried to "outsmart" this page by clicking on the chat button instead of the rescue button. They didn't believe their situation was an emergency, when they truly did need fuel. For this reason, language which would imply clicking the "get rescued" button would mean signaling an emergency or priority situation was strictly avoided. Instead, the choices are "get fuel" or "chat with the rats", which will encourage similar minded clients to click the correct button.

Finally, some fine print has been added to the bottom of the page which links to our ToS (and by extension CoC), and PP. This is to increase overall visibility of our policies in case any ToS breaking activity arises.





![New I Need Fuel page](https://www.uncleclapton.me/u/1801/1514951312.png)
