### PR TITLE
Paperwork fixes.

### DIFF
--- a/components/TagsInput.js
+++ b/components/TagsInput.js
@@ -74,7 +74,7 @@ export default class TagsInputComponent extends React.Component {
 
   componentDidUpdate (prevProps, prevState) {
     if (this.props.onChange && (prevState.tags !== this.state.tags)) {
-      this.props.onChange(this.state.tags)
+      this.props.onChange(this.state.tags, this.props.name)
     }
   }
 

--- a/components/TagsInput.js
+++ b/components/TagsInput.js
@@ -190,10 +190,18 @@ export default class TagsInputComponent extends React.Component {
   getValue (option) {
     let value = option
 
-    for (const key of this.valueProp.split('.')) {
-      value = value[key]
+    switch (typeof this.valueProp) {
+      case 'function':
+        value = this.valueProp(option)
+        break
+      case 'string':
+        for (const key of this.valueProp.split('.')) {
+          value = value[key]
+        }
+        break
+      default:
+        throw new TypeError('valueProp must be either a string pointer or function.')
     }
-
     return value
   }
 

--- a/pages/paperwork/edit.js
+++ b/pages/paperwork/edit.js
@@ -309,7 +309,8 @@ class Paperwork extends Component {
                   id="codeRed-no"
                   name="codeRed"
                   onChange={this.handleChange}
-                  type="radio" /> <label htmlFor="codeRed-no">No</label>
+                  type="radio"
+                  value="false" /> <label htmlFor="codeRed-no">No</label>
               </div>
             </fieldset>
 


### PR DESCRIPTION
4 big changes here. 

Fix the CR "no" radio button so it correctly reports a value of "false".

Refactor 2 functions of TagsInput. The first is the function which calls onChange. onChange now gets passed the name prop of the input instance for contextual reference purposes. The second is the getValue function. getValue now accepts both a string pointer or a function which gets passed the option object. Both of these changes are to support the two changes below.

Fix the system field so that it correctly sets the system name. The issue here was that we were passing TagsInput the string name not the object containing the value of the system.

Add platforms to rat names to remove any question of which rat is which when a rescue has it's platform switched. This has been enough of a problem to warrant the extra data, even if it is redundant. The refactor to allow this change will also be important in an upcoming PR which will add the displayRat form to the rats management page.