### PR TITLE
Update authorize.js

### DIFF
--- a/pages/authorize.js
+++ b/pages/authorize.js
@@ -95,7 +95,7 @@ class Authorize extends Component {
 
             <ul>
               {this.state.scopes.map(scopeData => (
-                <li key={scopeData} className={scopeData.accessible ? 'inaccessible' : null}>{scopeData.permission}</li>
+                <li key={scopeData} className={scopeData.accessible ? null : 'inaccessible'}>{scopeData.permission}</li>
               ))}
             </ul>
 


### PR DESCRIPTION
The logic for the 'strikethrough' text when a permission on the authorise page is inaccessible is incorrect and does the opposite of what it's supposed to, this corrects it.