### PR TITLE
Fix issues introduced by #102

### DIFF
--- a/pages/authorize.js
+++ b/pages/authorize.js
@@ -36,21 +36,15 @@ class Authorize extends Component {
     Public Methods
   \***************************************************************************/
 
-  static async getInitialProps ({ query, store, accessToken }) {
+  static async getInitialProps ({
+    accessToken, query, store,
+  }) {
     const {
       client_id: clientId,
-      state,
-      scope,
       response_type: responseType,
     } = query
 
-    const { payload, status } = await actions.getClientOAuthPage({
-      clientId,
-      responseType,
-      scope,
-      state,
-    })(store.dispatch)
-
+    const { payload, status } = await actions.getClientOAuthPage(query)(store.dispatch)
 
     if (status === 'success') {
       const {

--- a/pages/authorize.js
+++ b/pages/authorize.js
@@ -37,7 +37,7 @@ class Authorize extends Component {
   \***************************************************************************/
 
   static async getInitialProps ({
-    accessToken, query, store,
+    accessToken, query, res, store,
   }) {
     const {
       client_id: clientId,
@@ -50,7 +50,11 @@ class Authorize extends Component {
       const {
         client,
         ...oauthProps
-      } = payload
+      } = payload.data
+
+      if (res && payload.headers['set-cookie']) {
+        res.setHeader('set-cookie', payload.headers['set-cookie'])
+      }
 
       return {
         clientId,

--- a/store/actions/authentication.js
+++ b/store/actions/authentication.js
@@ -73,6 +73,7 @@ export const login = (email, password, route, routeParams) => createApiAction({
 export const getClientOAuthPage = params => createApiAction({
   actionType: actionTypes.GET_CLIENT_AUTHORIZATION_PAGE,
   url: '/oauth2/authorize',
+  onSuccess: res => res,
   params,
 })
 

--- a/store/actions/authentication.js
+++ b/store/actions/authentication.js
@@ -70,10 +70,10 @@ export const login = (email, password, route, routeParams) => createApiAction({
 })
 
 
-export const getClientOAuthPage = opts => createApiAction({
+export const getClientOAuthPage = params => createApiAction({
   actionType: actionTypes.GET_CLIENT_AUTHORIZATION_PAGE,
-  url: `/oauth2/authorize?client_id=${opts.clientId}&scope=${opts.scope}&response_type=${opts.responseType}${opts.state ? `&state=${opts.state}` : ''}`,
-  method: 'get',
+  url: '/oauth2/authorize',
+  params,
 })
 
 


### PR DESCRIPTION
* session information was not being relayed to the user since the api data was being loaded server-side
  * we now forward set-cookie headers from GET /oauth2/authorize to compensate
* streamline configuration of `getClientOauthPage` action