### PR TITLE
[WEB-291] better oauth error handling

### DIFF
--- a/src/components/LoginModal/LoginModalErrorBox.js
+++ b/src/components/LoginModal/LoginModalErrorBox.js
@@ -4,12 +4,15 @@ import React from 'react'
 import ApiErrorBox from '~/components/MessageBox/ApiErrorBox'
 
 function getErrorText (error) {
+  // Bad verification tokens are returned as oauth errors, which is weird but okay.
+  if (error.error_description === 'verify') {
+    return 'That verification token was incorrect. Please try again.'
+  }
+
   switch (error.status) {
     case 'verification_required':
-      if (error.source?.pointer === 'verify') {
-        return 'That verification token was incorrect.\nPlease try again.\n'
-      }
       return 'It appears you\'re logging in from a new device.\nA verification code has been sent to your email.'
+
     case 'unauthorized':
       return 'Invalid Username or Password'
 

--- a/src/helpers/getResponseError.js
+++ b/src/helpers/getResponseError.js
@@ -1,18 +1,28 @@
 import { isError } from 'flux-standard-action'
 
 export default function getResponseError (action) {
+  // Return if not valid FSA error
   if (!isError(action)) {
     return undefined
   }
 
+  // JSONAPI error object
   if (action.payload?.errors?.length) {
     return action.payload.errors[0]
   }
 
+  // oAuth 2.0 error object
+  if (typeof action.payload?.error === 'string' && typeof action.payload?.['error_description'] === 'string') {
+    return action.payload
+  }
+
+  // Internal error
   if (action.meta.error) {
     return action.meta.error
   }
 
+  // We have an error but it's not documented so we will simulate a 500.
+  // This honestly shouldn't happen ever, but a good safeguard.
   return {
     links: {
       about: 'https://httpstatuses.com/500',


### PR DESCRIPTION
* return oauth errors in `getResponseError`
* fix bad error detection in `<LoginModalErrorBox />`