### PR TITLE
Fix apple-app-site-association.js and error page

### DIFF
--- a/src/components/Forms/AddRatForm/AddRatForm.js
+++ b/src/components/Forms/AddRatForm/AddRatForm.js
@@ -1,13 +1,12 @@
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { useCallback, useState } from 'react'
-import { useDispatch, useSelector } from 'react-redux'
+import { useDispatch } from 'react-redux'
 
 import CMDRFieldset from '~/components/Fieldsets/CMDRFieldset'
 import ExpansionFieldset from '~/components/Fieldsets/ExpansionFieldset'
 import SelectFieldset from '~/components/Fieldsets/SelectFieldset'
 import useForm from '~/hooks/useForm'
 import { createRat } from '~/store/actions/rats'
-import { selectCurrentUserId } from '~/store/selectors'
 
 import styles from './AddRatForm.module.scss'
 
@@ -23,7 +22,6 @@ const initialState = {
 
 function AddRatForm () {
   const dispatch = useDispatch()
-  const userId = useSelector(selectCurrentUserId)
   const [formOpen, setFormOpen] = useState(false)
   const handleToggleForm = useCallback(() => {
     setFormOpen((state) => {
@@ -38,14 +36,6 @@ function AddRatForm () {
         name: name.trim(),
         platform,
         expansion: platform === 'pc' ? expansion : 'horizons3',
-      },
-      relationships: {
-        user: {
-          data: {
-            type: 'users',
-            id: userId,
-          },
-        },
       },
     }))
     setFormOpen(false)

--- a/src/pages/[slug].js
+++ b/src/pages/[slug].js
@@ -1,3 +1,4 @@
+import { HttpStatus } from '@fuelrats/web-util/http'
 import { isError } from 'flux-standard-action'
 
 import WordpressPage from '~/components/WordpressPage'
@@ -19,9 +20,14 @@ WordpressProxy.getInitialProps = async (ctx) => {
 
   if (!selectWordpressPageBySlug(store.getState(), { slug })) {
     const response = await store.dispatch(getWordpressPage(slug))
-    if (isError(response)) {
-      setError(ctx, response.meta?.response?.status)
+    if (!isError(response)) {
+      return
     }
+    if (!response.payload?.length) {
+      setError(ctx, HttpStatus.NOT_FOUND)
+      return
+    }
+    setError(ctx, response.meta?.response?.status)
   }
 }
 

--- a/src/pages/api/apple-app-site-association.js
+++ b/src/pages/api/apple-app-site-association.js
@@ -1,18 +1,18 @@
 import { HttpStatus } from '@fuelrats/web-util/http'
 
 /*
- * Almost always redirected from '/apple-app-site-Association'
+ * Almost always rewritten from '/.well-known/apple-app-site-Association'
  */
 export default function appleAppSiteAssociation (req, res) {
   res.status(HttpStatus.OK).json({
     appLinks: {
-      details: [
+      details: [{
         appIDs: ['9X89US848J.io.sorlie.Fuel-Rats'],
         components: [{
           '/': '/verify*',
-          'comment': 'used for handling password reset links in emails',
+          comment: 'used for handling password reset links in emails',
         }],
-      ],
+      }],
     },
     webcredentials: {
       apps: ['9X89US848J.io.sorlie.Fuel-Rats'],


### PR DESCRIPTION
<!-- ⚠⚠ Do not delete this template! ⚠⚠ -->
<!-- Pull requests that do not follow this template will be ignored. -->

<!-- Add the issues this PR closes below. -->
<!-- Additional issues should be defined with a full "Closes #[issue]" line to ensure GitHub automation operates as-expected. -->

## Changelog
<!-- Provide a summary of changes for this pull request in technical detail. -->
<!-- Empty sections of this changelog should be removed. -->

### 🐛 Fixes
* Fix invalid format of apple-app-site-association.js
*  Fix the /[slug].js route so that it correctly shows a 404 error page when the page cannot be located on wordpress rather than the confusing 200 error page.

## Additional Information

### apple-app-site-association.js
The error when running `yarn build` on the current version:
```
./src/pages/api/apple-app-site-association.js:10:14
Syntax error: Unexpected token, expected ","

   8 |     appLinks: {
   9 |       details: [
> 10 |         appIDs: ['9X89US848J.io.sorlie.Fuel-Rats'],
     |               ^
  11 |         components: [{
  12 |           '/': '/verify*',
  13 |           'comment': 'used for handling password reset links in emails',


> Build failed because of webpack errors
```

### Error page
Comparison of the error page when attempting to view a page that does not exist on the current version and after this fix:
| Current | Fixed |
|--------|--------|
| ![An error page showing the text "200 \| OK"](https://github.com/FuelRats/fuelrats.com/assets/58088721/b8fd1600-8073-41d5-92d9-b388d22866fb) | ![An error page showing the text "404 \| Not Found"](https://github.com/FuelRats/fuelrats.com/assets/58088721/452778ce-5cc1-4bd3-b0ae-4fa5995ef3f7) |


## Contributor's Checklist
<!-- All items listed here must be checked off for the PR to be accepted -->

- [ ] This PR was created to resolve an existing issue or set of issues.
- [ ] This PR satisfies any and all acceptance criteria laid out by issue(s) it resolves.
- [ ] I have discussed creating this PR with the maintainers in the issue(s) beforehand.
- [x] I have thoroughly tested the changes this PR introduces in a local development environment.
- [x] I have linted the entire codebase using `yarn lint` and confirmed there are no errors or warnings.
(This PR introduces no new errors/warnings)
- [x] I have followed the commit conventions laid out by [`CONTRIBUTING.md`](https://github.com/FuelRats/fuelrats.com/blob/develop/CONTRIBUTING.md#commit-conventions).
(The gitmoji format seems to be no longer used)

## Maintainer's Checklist
<!-- The following items only need to be completed by project maintainers. (A.K.A. The TechRats) -->
<!-- If you are not a TechRat, do not fill out this list. -->

- [ ] User-facing changes this PR introduces has been or will be documented in `CHANGELOG.md`.
- [ ] This PR has been linted and tested locally as a part of the review process.
- [ ] All issues this PR resolves have been properly linked before merging.

<!-- FIRST TIME CONTRIBUTORS -->
<!-- If you do not wish to be added to our all-contributors list, remove the "<!--" at the start of the line below -->

<!-- **I do not wish to be included as a contributor at this time** <!---->
