### PR TITLE
Fix typo on history page

### DIFF
--- a/src/pages/history/index.js
+++ b/src/pages/history/index.js
@@ -77,7 +77,7 @@ function History () {
         <br />
 
         {'Want to know more about the history of the Fuel Rats? We have a more in-depth history available '}
-        <a href="https://confluence.fuelrats.com/display/public/FRKB/History" rel="noreferrer" target="_blank">{'on our knowledgebase'}</a>{'.'}
+        <a href="https://confluence.fuelrats.com/display/public/FRKB/History" rel="noreferrer" target="_blank">{'on our knowledge base'}</a>{'.'}
       </div>
     </div>
   )


### PR DESCRIPTION
Just after the new pages went live, it was pointed out to me that we use the spelling "knowledge base" on Confluence, but I had used "knowledgebase" on the site. This tiny update fixes that oversight to keep things consistent.