### PR TITLE
Remove disable profile button from profile

### DIFF
--- a/src/components/ProfileHeader/ProfileHeader.js
+++ b/src/components/ProfileHeader/ProfileHeader.js
@@ -13,7 +13,6 @@ import formatAsEliteDateTime from '~/util/date/formatAsEliteDateTime'
 
 import ChangeEmailModal from '../ChangeEmailModal'
 import ChangePasswordModal from '../ChangePasswordModal'
-import DisableProfileModal from '../DisableProfileModal'
 import ProfileUserAvatar from '../ProfileUserAvatar'
 import UnverifiedUserBanner from './UnverifiedUserBanner'
 
@@ -24,7 +23,6 @@ import UnverifiedUserBanner from './UnverifiedUserBanner'
 function ProfileHeader () {
   const [showChangeEmail, setShowChangeEmail] = useState(false)
   const [showChangePassword, setShowChangePassword] = useState(false)
-  const [showDisableProfile, setShowDisableProfile] = useState(false)
 
   const handleToggleChangeEmail = useCallback(() => {
     setShowChangeEmail((state) => {
@@ -34,12 +32,6 @@ function ProfileHeader () {
 
   const handleToggleChangePassword = useCallback(() => {
     setShowChangePassword((state) => {
-      return !state
-    })
-  }, [])
-
-  const handleToggleDisableProfile = useCallback(() => {
-    setShowDisableProfile((state) => {
       return !state
     })
   }, [])
@@ -103,9 +95,6 @@ function ProfileHeader () {
       <ChangePasswordModal
         isOpen={showChangePassword}
         onClose={handleToggleChangePassword} />
-      <DisableProfileModal
-        isOpen={showDisableProfile}
-        onClose={handleToggleDisableProfile} />
     </>
   )
 }

--- a/src/components/ProfileHeader/ProfileHeader.js
+++ b/src/components/ProfileHeader/ProfileHeader.js
@@ -95,11 +95,6 @@ function ProfileHeader () {
             onClick={handleToggleChangePassword}>
             {'Change Password'}
           </button>
-          <button
-            type="button"
-            onClick={handleToggleDisableProfile}>
-            {'Disable Profile'}
-          </button>
         </div>
       </div>
       <ChangeEmailModal


### PR DESCRIPTION
Since the disable profile option has been removed from the API, let's remove the button that doesn't work too. I've left the modal alone for now, as I still think we should leave the functionality alone and just remove access for the user to disable their own account. That said, if the consensus is that the functionality should be removed completely, it's easy enough to clean up.