### PR TITLE
Actually copy commander name on CMDR col

### DIFF
--- a/src/components/DispatchTable/RescueRow.js
+++ b/src/components/DispatchTable/RescueRow.js
@@ -79,7 +79,6 @@ function RescueRow (props) {
   const {
     codeRed,
     status,
-    clientNick,
     client,
     commandIdentifier,
     expansion,
@@ -108,8 +107,8 @@ function RescueRow (props) {
         <CopyToClipboard
           doHint
           className={styles.cmdrNameCol}
-          text={clientNick ?? client}
-          title={clientNick ?? ''}>
+          text={client ?? ''}
+          title={client ?? ''}>
           <span className={styles.cmdrName}>
             {client ?? '?'}
           </span>


### PR DESCRIPTION
Title says what it does, copies commander name instead of IRC nick when clicking the CMDR column. Fixes #427 