### PR TITLE
fix: Missing active rescue register error handling

### DIFF
--- a/src/components/Forms/RegistrationForm/RegistrationErrorBox.js
+++ b/src/components/Forms/RegistrationForm/RegistrationErrorBox.js
@@ -24,6 +24,15 @@ function getErrorText (error) {
           return undefined
       }
 
+    case HttpStatus.FORBIDDEN:
+      switch (error.source?.pointer) {
+        case '/data/attributes/name':
+          return 'You do not need to register on fuelrats.com to be rescued, if you wish to become a rat you can sign up after your rescue.'
+
+        default:
+          return undefined
+      }
+
     default:
       return undefined
   }


### PR DESCRIPTION
<!--
  ⚠⚠ Do not ignore this template! ⚠⚠
  Pull requests that do not follow this format will be rejected!
-->

<!--
  Add the issues this PR closes below.
  Additional issues should be defined with a full "Closes #[issue]" line to ensure GitHub automation operates as-expected.
-->

Closes #409 

## Description
<!-- Provide a summary of changes for this pull request, and why they were implemented this way -->

* This adds the missing error handling for attempting to register while you are the client of an active rescue. This is intended to prevent clients from being distracted by needlessly creating an account on fuelrats.com while they are supposed to pay attention to the IRC, however as the website currently only shows an unknown error it instead results in the client repeatedly trying to register not understanding why it isn't working.

### Additional Information
<!-- Add any other context or development notes can go here. -->

*

### Demo
<!--
  In order to assist reviewers, Please include a screenshot or short video clip demonstrating your change in the details block below.
  If this PR does not contain any functional code change, this section may be removed.
-->

<details>
<summary>Demo</summary>



</details>

## Acceptance Tasks

### Contributor's Checklist
<!-- All items must be completed for the PR to be accepted -->

* [x] This PR was created to resolve an existing issue or set of issues.
* [x] This PR satisfies any and all acceptance criteria laid out by issue(s) it resolves.
* [ ] I have discussed creating this PR with the maintainers in the issue(s) beforehand.
* [x] I have thoroughly tested the changes this PR introduces in a local development environment.
* [x] I have linted the entire codebase using `yarn lint` and confirmed there are no errors or warnings.
* [x] I have followed the commit conventions laid out by [`CONTRIBUTING.md`](https://github.com/FuelRats/fuelrats.com/blob/develop/CONTRIBUTING.md#commit-conventions).

### Maintainer's Checklist
<!--
  The following items must be completed by project maintainers. (A.K.A. The TechRats)
  If you are not a TechRat, do not fill out this list.
-->

* [ ] User-facing changes this PR introduces have been captured in a changeset.
* [ ] This PR has been linted and tested locally as a part of the review process.
* [ ] All issues this PR resolves have been properly linked before merging.

<!-- FIRST TIME CONTRIBUTORS -->
<!-- If you do not wish to be added to our all-contributors list, remove the "<!--" at the start of the line below -->

<!-- **I do not wish to be included as a contributor at this time** <!---->
