### PR TITLE
Admin UI for permission-group management

### DIFF
--- a/src/components/GroupAdmin/CreateGroupModal.js
+++ b/src/components/GroupAdmin/CreateGroupModal.js
@@ -1,0 +1,93 @@
+import PropTypes from 'prop-types'
+import { useCallback, useState } from 'react'
+import { useDispatch } from 'react-redux'
+
+import asModal, { ModalContent, ModalFooter, FooterPrimary } from '~/components/asModal'
+import { createGroup } from '~/store/actions/groups'
+import getResponseError from '~/util/getResponseError'
+
+import styles from './GroupAdmin.module.scss'
+
+
+
+
+
+const NAME_PATTERN = /^[a-zA-Z0-9]+$/u
+
+
+function CreateGroupModal ({ onClose, onCreated }) {
+  const dispatch = useDispatch()
+  const [name, setName] = useState('')
+  const [error, setError] = useState(null)
+  const [saving, setSaving] = useState(false)
+
+  const valid = NAME_PATTERN.test(name)
+
+  const handleNameChange = useCallback((event) => {
+    setName(event.target.value)
+  }, [])
+
+  const handleCreate = useCallback(async () => {
+    setSaving(true)
+    setError(null)
+    const response = await dispatch(createGroup({ attributes: { name } }))
+    const err = getResponseError(response)
+    setSaving(false)
+    if (err) {
+      setError(err.detail ?? 'Failed to create group.')
+      return
+    }
+    // 201 carries the server-generated UUID — hand it back so the caller opens the editor on it.
+    onCreated(response.payload?.data?.id)
+  }, [dispatch, name, onCreated])
+
+  return (
+    <>
+      <ModalContent>
+        <label className={styles.flagCheck}>
+          {'Group name'}
+          <input
+            aria-label="New group name"
+            placeholder="alphanumeric"
+            type="text"
+            value={name}
+            onChange={handleNameChange} />
+        </label>
+        {
+          !valid && name.length > 0 && (
+            <p className={styles.error}>{'Name must be alphanumeric.'}</p>
+          )
+        }
+        {Boolean(error) && (<p className={styles.error}>{error}</p>)}
+        <p className={styles.sectionHint}>
+          {'Channels and permissions are added after the group is created.'}
+        </p>
+      </ModalContent>
+      <ModalFooter>
+        <FooterPrimary>
+          <button
+            className="green"
+            disabled={!valid || saving}
+            type="button"
+            onClick={handleCreate}>
+            {saving ? 'Creating...' : 'Create group'}
+          </button>
+          <button type="button" onClick={onClose}>
+            {'Cancel'}
+          </button>
+        </FooterPrimary>
+      </ModalFooter>
+    </>
+  )
+}
+
+CreateGroupModal.propTypes = {
+  onClose: PropTypes.func.isRequired,
+  onCreated: PropTypes.func.isRequired,
+}
+
+
+
+
+
+export default asModal({ title: 'New group' })(CreateGroupModal)

--- a/src/components/GroupAdmin/GroupAdmin.module.scss
+++ b/src/components/GroupAdmin/GroupAdmin.module.scss
@@ -1,0 +1,230 @@
+@import '../../scss/colors';
+
+.section {
+  margin-bottom: 1.5rem;
+  padding-bottom: 1.5rem;
+
+  border-bottom: 1px solid $grey-dark;
+
+  &:last-child {
+    margin-bottom: 0;
+    padding-bottom: 0;
+
+    border-bottom: none;
+  }
+}
+
+.sectionTitle {
+  margin: 0 0 0.75rem;
+
+  font-size: 1rem;
+  text-transform: uppercase;
+}
+
+.sectionHint {
+  margin: -0.5rem 0 0.75rem;
+
+  color: $grey;
+
+  font-size: 0.85rem;
+}
+
+.scalarGrid {
+  display: grid;
+  gap: 0.75rem 1rem;
+
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+
+  label {
+    display: flex;
+
+    flex-direction: column;
+    gap: 0.25rem;
+
+    font-size: 0.9rem;
+  }
+
+  input[type='text'],
+  input[type='number'] {
+    width: 100%;
+  }
+}
+
+.switchRow {
+  display: flex;
+
+  align-items: center;
+  gap: 0.5rem;
+
+  margin-top: 0.75rem;
+}
+
+.savedNote {
+  color: $green;
+
+  font-size: 0.85rem;
+}
+
+.channelList {
+  display: flex;
+
+  flex-direction: column;
+  gap: 0.5rem;
+
+  margin-bottom: 0.75rem;
+}
+
+.channelRow {
+  display: flex;
+
+  align-items: center;
+  gap: 0.75rem;
+
+  padding: 0.4rem 0.6rem;
+
+  border: 1px solid $grey-dark;
+  border-radius: 4px;
+}
+
+.channelName {
+  min-width: 8rem;
+
+  font-weight: bold;
+  font-family: monospace;
+}
+
+.flagBadges {
+  display: flex;
+
+  flex-wrap: wrap;
+
+  flex: 1;
+  gap: 0.25rem;
+}
+
+.flagBadge {
+  padding: 0.1rem 0.4rem;
+
+  border-radius: 3px;
+
+  background-color: rgba($grey, 0.15);
+
+  font-size: 0.8rem;
+}
+
+.rowActions {
+  display: flex;
+  gap: 0.35rem;
+
+  margin-left: auto;
+}
+
+.picker {
+  margin-top: 0.5rem;
+  padding: 0.75rem;
+
+  border: 1px solid $grey-dark;
+  border-radius: 4px;
+
+  background-color: rgba($grey, 0.05);
+}
+
+.flagCategories {
+  display: grid;
+  gap: 1rem;
+
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+
+  margin: 0.75rem 0;
+}
+
+.flagCategory {
+  legend {
+    margin-bottom: 0.35rem;
+
+    color: $grey;
+
+    font-size: 0.8rem;
+    text-transform: uppercase;
+  }
+}
+
+.flagCheck {
+  display: flex;
+
+  align-items: baseline;
+  gap: 0.4rem;
+
+  margin-bottom: 0.25rem;
+
+  font-size: 0.85rem;
+
+  input {
+    margin-top: 0.2rem;
+  }
+}
+
+.flagCheckDesc {
+  display: block;
+
+  color: $grey;
+
+  font-size: 0.75rem;
+}
+
+.permGrid {
+  display: flex;
+
+  flex-direction: column;
+  gap: 0.4rem;
+}
+
+.permRow {
+  display: flex;
+
+  align-items: center;
+  gap: 1rem;
+
+  padding: 0.35rem 0.6rem;
+
+  border: 1px solid $grey-dark;
+  border-radius: 4px;
+}
+
+.permDomain {
+  min-width: 9rem;
+
+  font-weight: bold;
+}
+
+.permChecks {
+  display: flex;
+
+  flex-wrap: wrap;
+  gap: 0.75rem;
+}
+
+.permCheck {
+  display: flex;
+
+  align-items: center;
+  gap: 0.3rem;
+
+  font-size: 0.85rem;
+  white-space: nowrap;
+}
+
+.pickerActions {
+  display: flex;
+  gap: 0.5rem;
+
+  margin-top: 0.5rem;
+}
+
+.error {
+  margin: 0.5rem 0;
+
+  color: $red;
+
+  font-size: 0.85rem;
+}

--- a/src/components/GroupAdmin/GroupChannelsSection.js
+++ b/src/components/GroupAdmin/GroupChannelsSection.js
@@ -1,5 +1,7 @@
 import PropTypes from 'prop-types'
-import { useCallback, useMemo, useState } from 'react'
+import {
+  useCallback, useEffect, useMemo, useState,
+} from 'react'
 import { useDispatch } from 'react-redux'
 
 import {
@@ -8,10 +10,11 @@ import {
   describeFlags,
   isValidFlags,
 } from '~/data/groupChannelFlags'
-import { setGroupChannel, removeGroupChannel } from '~/store/actions/groups'
+import { setGroupChannel, removeGroupChannel, getRegisteredChannels } from '~/store/actions/groups'
 import getResponseError from '~/util/getResponseError'
 
 import ConfirmActionButton from '../ConfirmActionButton'
+import TagsInput from '../TagsInput'
 import styles from './GroupAdmin.module.scss'
 
 
@@ -31,6 +34,7 @@ function ChannelFlagPicker (props) {
     initialChannel = '',
     initialFlags = '',
     isNew,
+    registeredChannels,
     onSave,
     onCancel,
   } = props
@@ -42,9 +46,28 @@ function ChannelFlagPicker (props) {
   const [error, setError] = useState(null)
   const [saving, setSaving] = useState(false)
 
-  const handleChannelChange = useCallback((event) => {
-    setChannel(event.target.value)
+  // Stable array identity so a flag toggle (parent re-render) doesn't churn TagsInput's value sync.
+  const channelValue = useMemo(() => {
+    return channel ? [channel] : []
+  }, [channel])
+
+  // TagsInput single-select: onAdd/onRemove pass the tag directly and fire
+  // reliably (onChange's array arg races React's lazy state update).
+  const handleChannelAdd = useCallback((tag) => {
+    setChannel(tag?.value ?? '')
   }, [])
+
+  const handleChannelRemove = useCallback(() => {
+    setChannel('')
+  }, [])
+
+  // Suggest registered channels, matching with or without the leading `#`.
+  const handleChannelSearch = useCallback((query) => {
+    const needle = query.replace(/^#/u, '').toLowerCase()
+    return registeredChannels.filter((name) => {
+      return name.replace(/^#/u, '').toLowerCase().includes(needle)
+    })
+  }, [registeredChannels])
 
   const handleToggle = useCallback((letter) => {
     setChecked((prev) => {
@@ -86,13 +109,29 @@ function ChannelFlagPicker (props) {
     <div className={styles.picker}>
       <label className={styles.flagCheck}>
         {'Channel'}
-        <input
-          aria-label="Channel name"
-          disabled={!isNew}
-          placeholder="#channel"
-          type="text"
-          value={channel}
-          onChange={handleChannelChange} />
+        {
+          isNew
+            ? (
+              <TagsInput
+                data-allownew
+                data-single
+                aria-label="Channel name"
+                placeholder="#channel"
+                value={channelValue}
+                valueProp="value"
+                onAdd={handleChannelAdd}
+                onRemove={handleChannelRemove}
+                onSearch={handleChannelSearch} />
+            )
+            : (
+              <input
+                disabled
+                readOnly
+                aria-label="Channel name"
+                type="text"
+                value={`#${channel.replace(/^#/u, '')}`} />
+            )
+        }
       </label>
 
       <div className={styles.flagCategories}>
@@ -155,6 +194,7 @@ ChannelFlagPicker.propTypes = {
   isNew: PropTypes.bool,
   onCancel: PropTypes.func.isRequired,
   onSave: PropTypes.func.isRequired,
+  registeredChannels: PropTypes.arrayOf(PropTypes.string).isRequired,
 }
 
 
@@ -166,6 +206,19 @@ function GroupChannelsSection ({ group }) {
   const channels = group.attributes.channels ?? {}
   // `editing` is null (closed), '' (adding new), or a bare channel key (editing existing).
   const [editing, setEditing] = useState(null)
+  const [registeredChannels, setRegisteredChannels] = useState([])
+
+  useEffect(() => {
+    let active = true
+    dispatch(getRegisteredChannels()).then((response) => {
+      if (active && Array.isArray(response.payload?.channels)) {
+        setRegisteredChannels(response.payload.channels)
+      }
+    })
+    return () => {
+      active = false
+    }
+  }, [dispatch])
 
   const channelEntries = useMemo(() => {
     return Object.entries(group.attributes.channels ?? {}).sort(([keyA], [keyB]) => {
@@ -268,6 +321,7 @@ function GroupChannelsSection ({ group }) {
               initialChannel={editing}
               initialFlags={editing ? (channels[editing] ?? '') : ''}
               isNew={editing === ''}
+              registeredChannels={registeredChannels}
               onCancel={handleCancelEdit}
               onSave={handleSave} />
           )

--- a/src/components/GroupAdmin/GroupChannelsSection.js
+++ b/src/components/GroupAdmin/GroupChannelsSection.js
@@ -1,0 +1,287 @@
+import PropTypes from 'prop-types'
+import { useCallback, useMemo, useState } from 'react'
+import { useDispatch } from 'react-redux'
+
+import {
+  FLAG_CATEGORIES,
+  FLAG_ORDER,
+  describeFlags,
+  isValidFlags,
+} from '~/data/groupChannelFlags'
+import { setGroupChannel, removeGroupChannel } from '~/store/actions/groups'
+import getResponseError from '~/util/getResponseError'
+
+import ConfirmActionButton from '../ConfirmActionButton'
+import styles from './GroupAdmin.module.scss'
+
+
+
+
+
+// Assemble the checked letters into a flag string in the catalog's canonical order.
+const assembleFlags = (checked) => {
+  return FLAG_ORDER.filter((letter) => {
+    return checked.has(letter)
+  }).join('')
+}
+
+
+function ChannelFlagPicker (props) {
+  const {
+    initialChannel = '',
+    initialFlags = '',
+    isNew,
+    onSave,
+    onCancel,
+  } = props
+
+  const [channel, setChannel] = useState(initialChannel)
+  const [checked, setChecked] = useState(() => {
+    return new Set(Array.from(initialFlags))
+  })
+  const [error, setError] = useState(null)
+  const [saving, setSaving] = useState(false)
+
+  const handleChannelChange = useCallback((event) => {
+    setChannel(event.target.value)
+  }, [])
+
+  const handleToggle = useCallback((letter) => {
+    setChecked((prev) => {
+      const next = new Set(prev)
+      if (next.has(letter)) {
+        next.delete(letter)
+      } else {
+        next.add(letter)
+      }
+      return next
+    })
+  }, [])
+
+  const handleSave = useCallback(async () => {
+    const bareKey = channel.replace(/^[#&]/u, '').trim()
+    if (!bareKey) {
+      setError('Enter a channel name.')
+      return
+    }
+    const flags = assembleFlags(checked)
+    if (!flags) {
+      setError('Select at least one flag.')
+      return
+    }
+    if (!isValidFlags(flags)) {
+      setError('One or more flags are invalid.')
+      return
+    }
+    setSaving(true)
+    setError(null)
+    const saveError = await onSave(bareKey, flags)
+    setSaving(false)
+    if (saveError) {
+      setError(saveError)
+    }
+  }, [channel, checked, onSave])
+
+  return (
+    <div className={styles.picker}>
+      <label className={styles.flagCheck}>
+        {'Channel'}
+        <input
+          aria-label="Channel name"
+          disabled={!isNew}
+          placeholder="#channel"
+          type="text"
+          value={channel}
+          onChange={handleChannelChange} />
+      </label>
+
+      <div className={styles.flagCategories}>
+        {
+          FLAG_CATEGORIES.map((category) => {
+            return (
+              <fieldset key={category.key} className={styles.flagCategory}>
+                <legend>{category.label}</legend>
+                {
+                  category.flags.map((flag) => {
+                    return (
+                      <label key={flag.letter} className={styles.flagCheck} title={flag.description}>
+                        <input
+                          aria-label={flag.label}
+                          checked={checked.has(flag.letter)}
+                          type="checkbox"
+                          onChange={
+                            () => {
+                              return handleToggle(flag.letter)
+                            }
+                          } />
+                        <span>
+                          {flag.label}
+                          <span className={styles.flagCheckDesc}>{flag.description}</span>
+                        </span>
+                      </label>
+                    )
+                  })
+                }
+              </fieldset>
+            )
+          })
+        }
+      </div>
+
+      {Boolean(error) && (<p className={styles.error}>{error}</p>)}
+
+      <div className={styles.pickerActions}>
+        <button
+          className="green compact"
+          disabled={saving}
+          type="button"
+          onClick={handleSave}>
+          {saving ? 'Saving...' : 'Save channel'}
+        </button>
+        <button
+          className="compact"
+          type="button"
+          onClick={onCancel}>
+          {'Cancel'}
+        </button>
+      </div>
+    </div>
+  )
+}
+
+ChannelFlagPicker.propTypes = {
+  initialChannel: PropTypes.string,
+  initialFlags: PropTypes.string,
+  isNew: PropTypes.bool,
+  onCancel: PropTypes.func.isRequired,
+  onSave: PropTypes.func.isRequired,
+}
+
+
+
+
+
+function GroupChannelsSection ({ group }) {
+  const dispatch = useDispatch()
+  const channels = group.attributes.channels ?? {}
+  // `editing` is null (closed), '' (adding new), or a bare channel key (editing existing).
+  const [editing, setEditing] = useState(null)
+
+  const channelEntries = useMemo(() => {
+    return Object.entries(group.attributes.channels ?? {}).sort(([keyA], [keyB]) => {
+      return keyA.localeCompare(keyB)
+    })
+  }, [group.attributes.channels])
+
+  const handleSave = useCallback(async (bareKey, flags) => {
+    const response = await dispatch(setGroupChannel(group.id, bareKey, flags))
+    const err = getResponseError(response)
+    if (err) {
+      return err.detail ?? 'Failed to save channel.'
+    }
+    setEditing(null)
+    return null
+  }, [dispatch, group.id])
+
+  const handleRemove = useCallback(async (bareKey) => {
+    const response = await dispatch(removeGroupChannel(group.id, bareKey))
+    const err = getResponseError(response)
+    return !err
+  }, [dispatch, group.id])
+
+  const handleAddNew = useCallback(() => {
+    setEditing('')
+  }, [])
+
+  const handleCancelEdit = useCallback(() => {
+    setEditing(null)
+  }, [])
+
+  return (
+    <section className={styles.section}>
+      <h3 className={styles.sectionTitle}>{'Channel access'}</h3>
+      <p className={styles.sectionHint}>
+        {'IRC channels this group grants access to, with the privileges applied on join.'}
+      </p>
+
+      <div className={styles.channelList}>
+        {
+          channelEntries.length === 0 && (
+            <p className={styles.sectionHint}>{'No channels configured.'}</p>
+          )
+        }
+        {
+          channelEntries.map(([bareKey, flags]) => {
+            return (
+              <div key={bareKey} className={styles.channelRow}>
+                <span className={styles.channelName}>{`#${bareKey}`}</span>
+                <span className={styles.flagBadges}>
+                  {
+                    describeFlags(flags).map((label, index) => {
+                      // eslint-disable-next-line react/no-array-index-key -- flag order is stable per render
+                      return (<span key={`${bareKey}-${index}`} className={styles.flagBadge}>{label}</span>)
+                    })
+                  }
+                </span>
+                <span className={styles.rowActions}>
+                  <button
+                    aria-label={`Edit #${bareKey}`}
+                    className="compact"
+                    type="button"
+                    onClick={
+                      () => {
+                        return setEditing(bareKey)
+                      }
+                    }>
+                    {'Edit'}
+                  </button>
+                  <ConfirmActionButton
+                    aria-label={`Remove #${bareKey}`}
+                    confirmButtonText="Remove"
+                    onConfirm={
+                      () => {
+                        return handleRemove(bareKey)
+                      }
+                    }>
+                    {'Remove'}
+                  </ConfirmActionButton>
+                </span>
+              </div>
+            )
+          })
+        }
+      </div>
+
+      {
+        editing === null
+          ? (
+            <button
+              className="compact"
+              type="button"
+              onClick={handleAddNew}>
+              {'Add channel'}
+            </button>
+          )
+          : (
+            <ChannelFlagPicker
+              key={editing || 'new'}
+              initialChannel={editing}
+              initialFlags={editing ? (channels[editing] ?? '') : ''}
+              isNew={editing === ''}
+              onCancel={handleCancelEdit}
+              onSave={handleSave} />
+          )
+      }
+    </section>
+  )
+}
+
+GroupChannelsSection.propTypes = {
+  group: PropTypes.object.isRequired,
+}
+
+
+
+
+
+export default GroupChannelsSection

--- a/src/components/GroupAdmin/GroupEditModal.js
+++ b/src/components/GroupAdmin/GroupEditModal.js
@@ -1,0 +1,244 @@
+import PropTypes from 'prop-types'
+import { useCallback, useMemo, useState } from 'react'
+import { useDispatch, useSelector } from 'react-redux'
+
+import asModal, { ModalContent, ModalFooter, FooterPrimary, FooterSecondary } from '~/components/asModal'
+import { updateGroup, deleteGroup } from '~/store/actions/groups'
+import { selectGroupById } from '~/store/selectors'
+import getResponseError from '~/util/getResponseError'
+
+import ConfirmActionButton from '../ConfirmActionButton'
+import styles from './GroupAdmin.module.scss'
+import GroupChannelsSection from './GroupChannelsSection'
+import GroupPermissionsSection from './GroupPermissionsSection'
+import ApiErrorBox from '../MessageBox/ApiErrorBox'
+
+
+
+
+
+const NAME_PATTERN = /^[a-zA-Z0-9]+$/u
+
+
+function GroupScalarsSection ({ group }) {
+  const dispatch = useDispatch()
+  const { attributes } = group
+
+  const [form, setForm] = useState({
+    name: attributes.name ?? '',
+    displayName: attributes.displayName ?? '',
+    vhost: attributes.vhost ?? '',
+    priority: attributes.priority ?? 0,
+    withoutPrefix: attributes.withoutPrefix ?? false,
+  })
+  const [error, setError] = useState(null)
+  const [saving, setSaving] = useState(false)
+  const [saved, setSaved] = useState(false)
+
+  const setField = useCallback((key, value) => {
+    setSaved(false)
+    setForm((prev) => {
+      return { ...prev, [key]: value }
+    })
+  }, [])
+
+  const handleNameChange = useCallback((event) => {
+    setField('name', event.target.value)
+  }, [setField])
+
+  const handleDisplayNameChange = useCallback((event) => {
+    setField('displayName', event.target.value)
+  }, [setField])
+
+  const handleVhostChange = useCallback((event) => {
+    setField('vhost', event.target.value)
+  }, [setField])
+
+  const handlePriorityChange = useCallback((event) => {
+    setField('priority', event.target.value)
+  }, [setField])
+
+  const handleWithoutPrefixChange = useCallback((event) => {
+    setField('withoutPrefix', event.target.checked)
+  }, [setField])
+
+  // Only attributes that actually changed, so an unrelated tweak never re-fans-out vhost.
+  const changedAttributes = useMemo(() => {
+    const changed = {}
+    if (form.name !== (attributes.name ?? '')) {
+      changed.name = form.name
+    }
+    if (form.displayName !== (attributes.displayName ?? '')) {
+      changed.displayName = form.displayName
+    }
+    if (form.vhost !== (attributes.vhost ?? '')) {
+      changed.vhost = form.vhost
+    }
+    if (Number(form.priority) !== (attributes.priority ?? 0)) {
+      changed.priority = Number(form.priority)
+    }
+    if (form.withoutPrefix !== (attributes.withoutPrefix ?? false)) {
+      changed.withoutPrefix = form.withoutPrefix
+    }
+    return changed
+  }, [form, attributes])
+
+  const nameValid = NAME_PATTERN.test(form.name)
+  const dirty = Object.keys(changedAttributes).length > 0
+
+  const handleSave = useCallback(async () => {
+    setSaving(true)
+    setError(null)
+    setSaved(false)
+    const response = await dispatch(updateGroup({ id: group.id, ...changedAttributes }))
+    const err = getResponseError(response)
+    setSaving(false)
+    if (err) {
+      setError(err)
+    } else {
+      setSaved(true)
+    }
+  }, [dispatch, group.id, changedAttributes])
+
+  return (
+    <section className={styles.section}>
+      <h3 className={styles.sectionTitle}>{'Details'}</h3>
+
+      <ApiErrorBox error={error} />
+
+      <div className={styles.scalarGrid}>
+        <label>
+          {'Name'}
+          <input
+            aria-label="Group name"
+            type="text"
+            value={form.name}
+            onChange={handleNameChange} />
+        </label>
+        <label>
+          {'Display name'}
+          <input
+            aria-label="Group display name"
+            type="text"
+            value={form.displayName}
+            onChange={handleDisplayNameChange} />
+        </label>
+        <label>
+          {'vHost'}
+          <input
+            aria-label="Group vhost"
+            placeholder="example.fuelrats.com"
+            type="text"
+            value={form.vhost}
+            onChange={handleVhostChange} />
+        </label>
+        <label>
+          {'Priority'}
+          <input
+            aria-label="Group priority"
+            type="number"
+            value={form.priority}
+            onChange={handlePriorityChange} />
+        </label>
+      </div>
+
+      <label className={styles.switchRow}>
+        <input
+          aria-label="Apply vhost without rat-name prefix"
+          checked={form.withoutPrefix}
+          type="checkbox"
+          onChange={handleWithoutPrefixChange} />
+        {'Apply vHost without rat-name prefix'}
+      </label>
+
+      <p className={styles.sectionHint}>
+        {'Renaming a group can orphan external references (vHost masks, IRC configs). '}
+        {'Changing the vHost or prefix re-applies host masks to every member.'}
+      </p>
+
+      <div className={styles.pickerActions}>
+        <button
+          className="green compact"
+          disabled={!dirty || saving || !nameValid}
+          type="button"
+          onClick={handleSave}>
+          {saving ? 'Saving...' : 'Save details'}
+        </button>
+        {!nameValid && (<span className={styles.error}>{'Name must be alphanumeric.'}</span>)}
+        {saved && (<span className={styles.savedNote}>{'Saved.'}</span>)}
+      </div>
+    </section>
+  )
+}
+
+GroupScalarsSection.propTypes = {
+  group: PropTypes.object.isRequired,
+}
+
+
+
+
+
+function GroupEditModal ({ groupId, onClose }) {
+  const dispatch = useDispatch()
+  const group = useSelector((state) => {
+    return selectGroupById(state, { groupId })
+  })
+  const [deleteError, setDeleteError] = useState(null)
+
+  const handleDelete = useCallback(async () => {
+    const response = await dispatch(deleteGroup(group))
+    const err = getResponseError(response)
+    if (err) {
+      setDeleteError(err.detail ?? 'Failed to delete group.')
+      return true
+    }
+    onClose()
+    return true
+  }, [dispatch, group, onClose])
+
+  if (!group) {
+    return (
+      <ModalContent>
+        <p>{'Group not found.'}</p>
+      </ModalContent>
+    )
+  }
+
+  return (
+    <>
+      <ModalContent>
+        <GroupScalarsSection group={group} />
+        <GroupChannelsSection group={group} />
+        <GroupPermissionsSection group={group} />
+        {Boolean(deleteError) && (<p className={styles.error}>{deleteError}</p>)}
+      </ModalContent>
+      <ModalFooter>
+        <FooterSecondary>
+          <ConfirmActionButton
+            confirmButtonText="Delete group"
+            confirmSubText="Delete this group and revoke it from all members?"
+            onConfirm={handleDelete}>
+            {'Delete group'}
+          </ConfirmActionButton>
+        </FooterSecondary>
+        <FooterPrimary>
+          <button type="button" onClick={onClose}>
+            {'Close'}
+          </button>
+        </FooterPrimary>
+      </ModalFooter>
+    </>
+  )
+}
+
+GroupEditModal.propTypes = {
+  groupId: PropTypes.string,
+  onClose: PropTypes.func.isRequired,
+}
+
+
+
+
+
+export default asModal({ className: 'group-edit-modal' })(GroupEditModal)

--- a/src/components/GroupAdmin/GroupPermissionsSection.js
+++ b/src/components/GroupAdmin/GroupPermissionsSection.js
@@ -1,0 +1,88 @@
+import PropTypes from 'prop-types'
+import { useCallback, useState } from 'react'
+import { useDispatch } from 'react-redux'
+
+import oauthScopes, { accessTypeLabel, domainLabel, scopeString } from '~/data/oauthScopes'
+import { setGroupPermission, removeGroupPermission } from '~/store/actions/groups'
+import getResponseError from '~/util/getResponseError'
+
+import styles from './GroupAdmin.module.scss'
+
+
+
+
+
+function GroupPermissionsSection ({ group }) {
+  const dispatch = useDispatch()
+  const permissions = group.attributes.permissions ?? []
+  const permSet = new Set(permissions)
+  const [error, setError] = useState(null)
+  const [pending, setPending] = useState(null)
+
+  const handleToggle = useCallback(async (scope, checked) => {
+    setPending(scope)
+    setError(null)
+    const action = checked ? setGroupPermission : removeGroupPermission
+    const response = await dispatch(action(group.id, scope))
+    const err = getResponseError(response)
+    setPending(null)
+    if (err) {
+      setError(err.detail ?? 'Failed to update permission.')
+    }
+  }, [dispatch, group.id])
+
+  return (
+    <section className={styles.section}>
+      <h3 className={styles.sectionTitle}>{'Permissions'}</h3>
+      <p className={styles.sectionHint}>
+        {'OAuth scopes granted to members of this group. Changes apply immediately.'}
+      </p>
+
+      {Boolean(error) && (<p className={styles.error}>{error}</p>)}
+
+      <div className={styles.permGrid}>
+        {
+          Object.entries(oauthScopes).map(([domain, accessTypes]) => {
+            return (
+              <div key={domain} className={styles.permRow}>
+                <span className={styles.permDomain}>{domainLabel(domain)}</span>
+                <span className={styles.permChecks}>
+                  {
+                    accessTypes.map((accessType) => {
+                      const scope = scopeString(domain, accessType)
+                      return (
+                        <label key={scope} className={styles.permCheck}>
+                          <input
+                            aria-label={`${domainLabel(domain)}: ${accessTypeLabel(accessType)}`}
+                            checked={permSet.has(scope)}
+                            disabled={pending === scope}
+                            type="checkbox"
+                            onChange={
+                              (event) => {
+                                return handleToggle(scope, event.target.checked)
+                              }
+                            } />
+                          {accessTypeLabel(accessType)}
+                        </label>
+                      )
+                    })
+                  }
+                </span>
+              </div>
+            )
+          })
+        }
+      </div>
+    </section>
+  )
+}
+
+GroupPermissionsSection.propTypes = {
+  group: PropTypes.object.isRequired,
+}
+
+
+
+
+
+export default GroupPermissionsSection

--- a/src/components/UserMenu/UserMenu.js
+++ b/src/components/UserMenu/UserMenu.js
@@ -46,6 +46,9 @@ function UserMenu () {
   const userCanAdminUsers = useSelector((state) => {
     return selectCurrentUserHasScope(state, { scope: 'users.write' })
   })
+  const userCanAdminGroups = useSelector((state) => {
+    return selectCurrentUserHasScope(state, { scope: 'groups.write' })
+  })
   const user = useSelector(withCurrentUserId(selectUserById))
 
   const dispatch = useDispatch()
@@ -115,7 +118,7 @@ function UserMenu () {
             </NavSection>
 
             {
-              (userCanAdminRescues || userCanAdminUsers) && (
+              (userCanAdminRescues || userCanAdminUsers || userCanAdminGroups) && (
                 <NavSection className={styles.navSection} title="Admin">
                   {
                     userCanAdminRescues && (
@@ -128,6 +131,13 @@ function UserMenu () {
                     userCanAdminUsers && (
                       <NavLink href="/admin/users">
                         {'User Admin'}
+                      </NavLink>
+                    )
+                  }
+                  {
+                    userCanAdminGroups && (
+                      <NavLink href="/admin/groups">
+                        {'Group Admin'}
                       </NavLink>
                     )
                   }

--- a/src/data/groupChannelFlags.js
+++ b/src/data/groupChannelFlags.js
@@ -1,0 +1,123 @@
+// Human-readable catalog for IRC channel-access FLAGS on a permission group.
+//
+// The API (api.fuelrats.com groupFlagLetters.mjs) validates flags against this exact
+// 26-letter set; lowercase `g` is intentionally NOT valid. Keep the catalog in sync.
+//
+// Each flag: { letter, label, description, modeGranting }. `modeGranting: true` marks
+// the durable auto-status modes applied on join (op/voice/etc). The UI shows the friendly
+// label — never a bare letter — as the primary control.
+
+// Authoritative valid set from the API, for the sync check. Order is irrelevant (set equality).
+const API_FLAG_LETTERS = 'ABFGHIKNOQUVabcfhikmoqstuv'
+
+const FLAG_CATEGORIES = [
+  {
+    key: 'status',
+    label: 'Status on join',
+    description: 'Channel status automatically applied when the member joins.',
+    flags: [
+      { letter: 'O', label: 'Auto-op', description: 'Opped (@) automatically on join.', modeGranting: true },
+      { letter: 'H', label: 'Auto-halfop', description: 'Given halfop (%) automatically on join.', modeGranting: true },
+      { letter: 'V', label: 'Auto-voice', description: 'Given voice (+) automatically on join.', modeGranting: true },
+      { letter: 'Q', label: 'Auto-owner', description: 'Given owner (~) automatically on join.', modeGranting: true },
+      { letter: 'A', label: 'Auto-admin', description: 'Given admin/protect (&) automatically on join.', modeGranting: true },
+    ],
+  },
+  {
+    key: 'founder',
+    label: 'Founder',
+    description: 'Full control of the channel.',
+    flags: [
+      { letter: 'F', label: 'Founder', description: 'Full founder-level control of the channel.', modeGranting: false },
+    ],
+  },
+  {
+    key: 'grant',
+    label: 'Grant status to others',
+    description: 'Ability to give channel status to other users.',
+    flags: [
+      { letter: 'o', label: 'Op others', description: 'Op and deop other users.', modeGranting: false },
+      { letter: 'h', label: 'Halfop others', description: 'Halfop and dehalfop other users.', modeGranting: false },
+      { letter: 'v', label: 'Voice others', description: 'Voice and devoice other users.', modeGranting: false },
+      { letter: 'q', label: 'Set owner', description: 'Grant and remove owner status.', modeGranting: false },
+      { letter: 'a', label: 'Set admin', description: 'Grant and remove admin/protect status.', modeGranting: false },
+    ],
+  },
+  {
+    key: 'moderation',
+    label: 'Moderation',
+    description: 'Channel moderation commands.',
+    flags: [
+      { letter: 'b', label: 'Ban', description: 'Ban users from the channel.', modeGranting: false },
+      { letter: 'k', label: 'Kick', description: 'Kick users from the channel.', modeGranting: false },
+      { letter: 'K', label: 'Manage auto-kick / bad-words', description: 'Manage the auto-kick and bad-words lists.', modeGranting: false },
+      { letter: 'N', label: 'Protected from kick', description: 'Cannot be kicked from the channel.', modeGranting: false },
+      { letter: 'u', label: 'Unban others', description: 'Remove bans on other users.', modeGranting: false },
+      { letter: 'U', label: 'Unban self', description: 'Remove bans that affect oneself.', modeGranting: false },
+      { letter: 't', label: 'Change topic', description: 'Change the channel topic.', modeGranting: false },
+    ],
+  },
+  {
+    key: 'management',
+    label: 'Management',
+    description: 'Channel settings and information.',
+    flags: [
+      { letter: 'f', label: 'Manage access list', description: 'Change the channel access list.', modeGranting: false },
+      { letter: 's', label: 'Change channel settings/modes', description: 'Change channel settings, modes, and assignments.', modeGranting: false },
+      { letter: 'G', label: 'View channel key', description: 'Retrieve the channel key.', modeGranting: false },
+      { letter: 'I', label: 'View channel info', description: 'View detailed channel information.', modeGranting: false },
+      { letter: 'i', label: 'Invite / self-invite', description: 'Invite oneself or others into the channel.', modeGranting: false },
+      { letter: 'm', label: 'Read channel memos', description: 'Read memos sent to the channel.', modeGranting: false },
+      { letter: 'c', label: 'Fantasy (!) commands', description: 'Use in-channel fantasy (!) commands.', modeGranting: false },
+      { letter: 'B', label: 'Make ChanServ speak', description: 'Make ChanServ say or act in the channel.', modeGranting: false },
+    ],
+  },
+]
+
+// Letter -> { letter, label, description, modeGranting, category } lookup.
+const FLAG_BY_LETTER = {}
+// Categorised render order (all valid letters, grouped).
+const FLAG_ORDER = []
+
+for (const category of FLAG_CATEGORIES) {
+  for (const flag of category.flags) {
+    FLAG_BY_LETTER[flag.letter] = { ...flag, category: category.key }
+    FLAG_ORDER.push(flag.letter)
+  }
+}
+
+// Single source of truth for validation, derived from the catalog above.
+const VALID_FLAG_SET = new Set(FLAG_ORDER)
+
+const flagLabel = (letter) => {
+  return FLAG_BY_LETTER[letter]?.label ?? letter
+}
+
+const flagInfo = (letter) => {
+  return FLAG_BY_LETTER[letter]
+}
+
+// "OV" -> ["Auto-op", "Auto-voice"] (unknown letters fall through as the raw letter).
+const describeFlags = (flags) => {
+  return Array.from(flags ?? '').map(flagLabel)
+}
+
+// True when every character of `flags` is a valid flag letter.
+const isValidFlags = (flags) => {
+  return Array.from(flags ?? '').every((letter) => {
+    return VALID_FLAG_SET.has(letter)
+  })
+}
+
+export {
+  API_FLAG_LETTERS,
+  FLAG_CATEGORIES,
+  FLAG_ORDER,
+  VALID_FLAG_SET,
+  flagLabel,
+  flagInfo,
+  describeFlags,
+  isValidFlags,
+}
+
+export default FLAG_BY_LETTER

--- a/src/data/oauthScopes.js
+++ b/src/data/oauthScopes.js
@@ -1,0 +1,79 @@
+// OAuth-scope taxonomy for the group-permission grid.
+//
+// Mirrors the grantable set in api.fuelrats.com `permissions.json`
+// (Permission.allPermissions, which feeds isValidOAuthScope). Keep the `oauthScopes`
+// map below in sync with that file — the API rejects any scope not listed there (400).
+//
+// This is NOT permissionNamespaces.js (that file is copy for the OAuth consent screen).
+
+// Friendly labels for each access type (the suffix after `<domain>.`).
+const ACCESS_TYPE_LABELS = {
+  'read.me': 'Read own',
+  read: 'Read all',
+  'write.me': 'Write own',
+  write: 'Write all',
+  verified: 'Verified',
+  forcedelete: 'Force-delete',
+}
+
+// Column order for the permission grid.
+const ACCESS_TYPE_ORDER = ['read.me', 'read', 'write.me', 'write', 'verified', 'forcedelete']
+
+// Friendly labels for each resource domain (grid row headers).
+const DOMAIN_LABELS = {
+  rescues: 'Rescues',
+  rats: 'Rats',
+  users: 'Users',
+  clients: 'OAuth Clients',
+  ships: 'Ships',
+  decals: 'Decals',
+  epics: 'Epics',
+  groups: 'Groups',
+  nicknames: 'Nicknames',
+  'rescue-revisions': 'Rescue Revisions',
+  resources: 'Resources',
+  twitter: 'Twitter',
+  dispatch: 'Dispatch',
+  anope: 'Anope (IRC)',
+}
+
+// Domain -> grantable access types. Mirror of permissions.json (14 domains).
+const oauthScopes = {
+  rescues: ['read.me', 'read', 'write.me', 'write'],
+  rats: ['read.me', 'read', 'write.me', 'write'],
+  users: ['read.me', 'read', 'write.me', 'write', 'verified'],
+  clients: ['read.me', 'read', 'write.me', 'write'],
+  ships: ['read.me', 'read', 'write.me', 'write'],
+  decals: ['read.me', 'read', 'write.me', 'write'],
+  epics: ['read.me', 'read', 'write.me', 'write'],
+  groups: ['read', 'write'],
+  nicknames: ['read.me', 'read', 'write.me', 'write'],
+  'rescue-revisions': ['read', 'write'],
+  resources: ['forcedelete'],
+  twitter: ['write'],
+  dispatch: ['read', 'write'],
+  anope: ['read'],
+}
+
+const scopeString = (domain, accessType) => {
+  return `${domain}.${accessType}`
+}
+
+const accessTypeLabel = (accessType) => {
+  return ACCESS_TYPE_LABELS[accessType] ?? accessType
+}
+
+const domainLabel = (domain) => {
+  return DOMAIN_LABELS[domain] ?? domain
+}
+
+export {
+  ACCESS_TYPE_LABELS,
+  ACCESS_TYPE_ORDER,
+  DOMAIN_LABELS,
+  scopeString,
+  accessTypeLabel,
+  domainLabel,
+}
+
+export default oauthScopes

--- a/src/pages/admin/groups/AdminGroups.module.scss
+++ b/src/pages/admin/groups/AdminGroups.module.scss
@@ -1,0 +1,71 @@
+@import '../../../scss/colors';
+
+.toolbar {
+  display: flex;
+
+  justify-content: flex-end;
+
+  margin-bottom: 1rem;
+}
+
+.tableWrap {
+  overflow: auto hidden;
+}
+
+.table {
+  min-width: 600px;
+  width: 100%;
+
+  border: 1px solid $grey-dark;
+
+  border-collapse: collapse;
+  table-layout: auto;
+
+  thead tr {
+    border-bottom: 2px solid $grey-dark;
+  }
+
+  th {
+    padding: 4px 8px;
+
+    color: $grey;
+
+    font-size: 0.85rem;
+    text-align: left;
+    text-transform: uppercase;
+    white-space: nowrap;
+  }
+
+  td {
+    padding: 0.5rem 0.8rem;
+
+    border-top: 1px solid $grey-dark;
+
+    line-height: 27px;
+    vertical-align: middle;
+  }
+
+  tbody tr {
+    transition: background-color 0.15s;
+
+    &:hover {
+      background-color: rgba($grey, 0.1);
+    }
+  }
+}
+
+.empty {
+  padding: 2rem;
+
+  color: $grey;
+
+  text-align: center;
+}
+
+.clickable {
+  cursor: pointer;
+
+  &:hover {
+    background-color: rgba($grey, 0.15);
+  }
+}

--- a/src/pages/admin/groups/index.js
+++ b/src/pages/admin/groups/index.js
@@ -1,0 +1,155 @@
+import {
+  useCallback, useEffect, useMemo, useState,
+} from 'react'
+import { useDispatch, useSelector } from 'react-redux'
+
+import { authenticated } from '~/components/AppLayout'
+import CreateGroupModal from '~/components/GroupAdmin/CreateGroupModal'
+import GroupEditModal from '~/components/GroupAdmin/GroupEditModal'
+import { getGroups } from '~/store/actions/user'
+import { selectGroups } from '~/store/selectors'
+import getResponseError from '~/util/getResponseError'
+
+import styles from './AdminGroups.module.scss'
+
+
+
+
+
+function AdminGroups () {
+  const dispatch = useDispatch()
+  const groups = useSelector(selectGroups)
+
+  const [loadState, setLoadState] = useState('loading')
+  const [editorGroupId, setEditorGroupId] = useState(null)
+  const [creating, setCreating] = useState(false)
+
+  const fetchGroups = useCallback(async () => {
+    setLoadState('loading')
+    const response = await dispatch(getGroups())
+    setLoadState(getResponseError(response) ? 'error' : 'ready')
+  }, [dispatch])
+
+  useEffect(() => {
+    fetchGroups()
+  }, [fetchGroups])
+
+  const groupList = useMemo(() => {
+    return Object.values(groups ?? {}).sort((groupA, groupB) => {
+      return (groupB.attributes.priority ?? 0) - (groupA.attributes.priority ?? 0)
+        || groupA.attributes.name.localeCompare(groupB.attributes.name)
+    })
+  }, [groups])
+
+  const editingGroup = editorGroupId ? groups[editorGroupId] : null
+
+  const handleCreated = useCallback((newId) => {
+    setCreating(false)
+    if (newId) {
+      setEditorGroupId(newId)
+    }
+  }, [])
+
+  const handleOpenCreate = useCallback(() => {
+    setCreating(true)
+  }, [])
+
+  const handleCloseCreate = useCallback(() => {
+    setCreating(false)
+  }, [])
+
+  const handleCloseEditor = useCallback(() => {
+    setEditorGroupId(null)
+  }, [])
+
+  const isEmpty = loadState === 'ready' && groupList.length === 0
+
+  return (
+    <div className="page-content">
+      <div className={styles.toolbar}>
+        <button
+          className="green compact"
+          type="button"
+          onClick={handleOpenCreate}>
+          {'New group'}
+        </button>
+      </div>
+
+      <div className={styles.tableWrap}>
+        <table className={styles.table}>
+          <thead>
+            <tr>
+              <th>{'Name'}</th>
+              <th>{'Display name'}</th>
+              <th>{'Priority'}</th>
+              <th>{'vHost'}</th>
+              <th>{'Channels'}</th>
+              <th>{'Scopes'}</th>
+            </tr>
+          </thead>
+          <tbody>
+            {
+              (loadState === 'loading' || loadState === 'error' || isEmpty) && (
+                <tr>
+                  <td className={styles.empty} colSpan={6}>
+                    {loadState === 'loading' && 'Loading...'}
+                    {loadState === 'error' && 'Failed to load groups.'}
+                    {isEmpty && 'No groups found.'}
+                  </td>
+                </tr>
+              )
+            }
+            {
+              groupList.map((group) => {
+                const {
+                  name, displayName, priority, vhost, channels, permissions,
+                } = group.attributes
+                return (
+                  <tr
+                    key={group.id}
+                    className={styles.clickable}
+                    onClick={
+                      () => {
+                        return setEditorGroupId(group.id)
+                      }
+                    }>
+                    <td>{name}</td>
+                    <td>{displayName}</td>
+                    <td>{priority ?? 0}</td>
+                    <td>{vhost || '—'}</td>
+                    <td>{Object.keys(channels ?? {}).length}</td>
+                    <td>{(permissions ?? []).length}</td>
+                  </tr>
+                )
+              })
+            }
+          </tbody>
+        </table>
+      </div>
+
+      <GroupEditModal
+        groupId={editorGroupId}
+        isOpen={Boolean(editorGroupId)}
+        title={editingGroup ? `Edit ${editingGroup.attributes.name}` : 'Edit group'}
+        onClose={handleCloseEditor} />
+
+      <CreateGroupModal
+        isOpen={creating}
+        onClose={handleCloseCreate}
+        onCreated={handleCreated} />
+    </div>
+  )
+}
+
+AdminGroups.getPageMeta = () => {
+  return {
+    title: 'Group Admin',
+    breadcrumbs: [{ label: 'Admin' }],
+  }
+}
+
+
+
+
+
+export default authenticated('groups.write')(AdminGroups)

--- a/src/services/frApi.js
+++ b/src/services/frApi.js
@@ -4,8 +4,14 @@ import qs from 'qs'
 
 const isServer = typeof window === 'undefined'
 
+// Server-side rendering hits the API directly when FR_SSR_API_URL is set, instead of
+// looping back through this app's own /api/fr proxy. The self-proxy deadlocks the Next
+// dev server (SSR blocks on a request it can't serve concurrently). Unset in production,
+// where SSR keeps proxying through APP_URL.
+const serverBaseURL = process.env.FR_SSR_API_URL ?? `${process.env.APP_URL}/api/fr`
+
 const frApi = axios.create({
-  baseURL: isServer ? `${process.env.APP_URL}/api/fr` : '/api/fr',
+  baseURL: isServer ? serverBaseURL : '/api/fr',
   timeout: 10000,
   paramsSerializer: qs.stringify,
 

--- a/src/store/actionTypes.js
+++ b/src/store/actionTypes.js
@@ -22,6 +22,9 @@ const epics = {
 const groups = {
   read: 'groups/read',
   search: 'groups/search',
+  create: 'groups/create',
+  update: 'groups/update',
+  delete: 'groups/delete',
 }
 
 

--- a/src/store/actionTypes.js
+++ b/src/store/actionTypes.js
@@ -25,6 +25,7 @@ const groups = {
   create: 'groups/create',
   update: 'groups/update',
   delete: 'groups/delete',
+  registeredChannels: 'groups/registeredChannels',
 }
 
 

--- a/src/store/actions/groups.js
+++ b/src/store/actions/groups.js
@@ -1,0 +1,92 @@
+import createRequestBody from '~/util/jsonapi/createRequestBody'
+
+import actionTypes from '../actionTypes'
+import { frApiRequest } from './services'
+import { deletesResource } from '../reducers/frAPIResources'
+
+
+// Channels are stored bare (no leading `#`); strip it and URL-encode for the path.
+const channelPath = (channel) => {
+  return encodeURIComponent(channel.replace(/^[#&]/u, ''))
+}
+
+
+export const createGroup = (data) => {
+  return frApiRequest(
+    actionTypes.groups.create,
+    {
+      url: '/groups',
+      method: 'post',
+      data: createRequestBody('groups', data),
+    },
+  )
+}
+
+
+export const updateGroup = (data) => {
+  return frApiRequest(
+    actionTypes.groups.update,
+    {
+      url: `/groups/${data.id}`,
+      method: 'put',
+      data: createRequestBody('groups', data),
+    },
+  )
+}
+
+
+export const deleteGroup = (group) => {
+  return frApiRequest(
+    actionTypes.groups.delete,
+    {
+      url: `/groups/${group.id}`,
+      method: 'delete',
+    },
+    deletesResource(group),
+  )
+}
+
+
+export const setGroupChannel = (id, channel, flags) => {
+  return frApiRequest(
+    actionTypes.groups.update,
+    {
+      url: `/groups/${id}/channels/${channelPath(channel)}`,
+      method: 'put',
+      data: { flags },
+    },
+  )
+}
+
+
+export const removeGroupChannel = (id, channel) => {
+  return frApiRequest(
+    actionTypes.groups.update,
+    {
+      url: `/groups/${id}/channels/${channelPath(channel)}`,
+      method: 'delete',
+    },
+  )
+}
+
+
+export const setGroupPermission = (id, scope) => {
+  return frApiRequest(
+    actionTypes.groups.update,
+    {
+      url: `/groups/${id}/permissions/${encodeURIComponent(scope)}`,
+      method: 'put',
+    },
+  )
+}
+
+
+export const removeGroupPermission = (id, scope) => {
+  return frApiRequest(
+    actionTypes.groups.update,
+    {
+      url: `/groups/${id}/permissions/${encodeURIComponent(scope)}`,
+      method: 'delete',
+    },
+  )
+}

--- a/src/store/actions/groups.js
+++ b/src/store/actions/groups.js
@@ -1,13 +1,23 @@
 import createRequestBody from '~/util/jsonapi/createRequestBody'
 
 import actionTypes from '../actionTypes'
-import { frApiRequest } from './services'
+import { frApiRequest, frApiPlainRequest } from './services'
 import { deletesResource } from '../reducers/frAPIResources'
 
 
 // Channels are stored bare (no leading `#`); strip it and URL-encode for the path.
 const channelPath = (channel) => {
   return encodeURIComponent(channel.replace(/^[#&]/u, ''))
+}
+
+
+// Registered ChanServ channels (plain `{ channels: [...] }`, not a JSON:API resource) —
+// backs the channel-access autocomplete so access is granted to real channels.
+export const getRegisteredChannels = () => {
+  return frApiPlainRequest(
+    actionTypes.groups.registeredChannels,
+    { url: '/anope/channels' },
+  )
 }
 
 

--- a/src/store/actions/user.js
+++ b/src/store/actions/user.js
@@ -140,10 +140,10 @@ export const setDisplayNickname = (nicknameId, displayNick) => {
 }
 
 
-export const getGroups = () => {
+export const getGroups = (params) => {
   return frApiRequest(
     actionTypes.groups.search,
-    { url: '/groups' },
+    { url: '/groups', params },
   )
 }
 


### PR DESCRIPTION
Adds an admin-only web UI to view and edit permission-group definitions — the web piece of the groupsync channel/permission management work, mirroring the SwiftSqueak `!addchan`/`!addperm`/etc. commands.

## What's included
- **List + editor** under `/admin/groups`, guarded by `authenticated('groups.write')`; a **Group Admin** nav link appears for `groups.write` admins.
- **Editor modal** with three sections:
  - **Details** — name (rename allowed) / displayName / vhost / priority / withoutPrefix, saved via one partial `PUT /groups/:id` (only changed attributes).
  - **Channel access** — flags shown as human-readable names (Auto-op, Voice, …) via a categorised checkbox picker; each save hits the atomic `PUT/DELETE /groups/:id/channels/:channel` endpoint. The channel field is an **autocomplete** backed by `GET /anope/channels`, so admins pick from channels actually registered with ChanServ.
  - **Permissions** — a faithful OAuth-scope grid (per-domain Read own / Read all / Write own / Write all + verified/force-delete), each toggle hitting the atomic permission endpoint.
- Create / confirm-gated delete via `POST`/`DELETE /groups`.
- New data catalogs mirrored from the API: `oauthScopes.js` (14 domains, matches `permissions.json`) and `groupChannelFlags.js` (26 flag letters, matches `groupFlagLetters.mjs`).

Store updates rely on the json-api reducer normalising the atomic endpoints' returned group (no refetch); removes work because the reducer replaces rather than deep-merges.

## Also here
- **SSR dev fix**: an opt-in `FR_SSR_API_URL` lets server-side rendering hit the API directly instead of looping back through this app's own `/api/fr` proxy, which deadlocks the Next dev server (every authenticated page 500s on hard load). Unset in production → behaviour unchanged.

## Depends on
The API side (atomic group endpoints, `GET /anope/channels`, `permissions.json` epics/dispatch.write) lands with the groupsync API branch. Requires `groups.read`/`groups.write` to be granted to the admin/netadmin group(s) on the deployment DB, or the page and bot commands 401.

## Verification
`bun run lint` + `bun run build` pass. Exercised end-to-end against a local API: list, create (201 → editor on new UUID), scalar partial-save, invalid-vhost 422 surfaced, channel add/remove (atomic), permission toggle (incl. epics/dispatch.write), delete, and the channel autocomplete against registered channels. No automated test runner exists in this repo.